### PR TITLE
dub path now configurable

### DIFF
--- a/lib/autocomplete-dcd.coffee
+++ b/lib/autocomplete-dcd.coffee
@@ -6,6 +6,7 @@ module.exports =
   activate: ->
     provider.updateServerCommand()
     provider.updateClientCommand()
+    provider.updateDubCommand()
     provider.updateProtoThreshold()
     provider.observeConfig()
 

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -11,6 +11,12 @@ module.exports =
     type: "string"
     default: "dcd-client"
 
+  dub:
+    title: "dub client command"
+    description: "The command to execute to launch dub"
+    type: "string"
+    default: "dub"
+
   protoThreshold:
     title: "Function prototype threshold"
     description: "If the number of functions showing in the suggestions is less or equal to this number, function prototypes will be shown (if set to -1 they will always show, but can have bad performance)"

--- a/lib/dcd-provider.coffee
+++ b/lib/dcd-provider.coffee
@@ -17,12 +17,16 @@ module.exports =
   updateClientCommand: ->
     @clientCommand = atom.config.get(packageName + ".dcdClient")
 
+  updateDubCommand: ->
+    @dubCommand = atom.config.get(packagename + ".dub")
+
   updateProtoThreshold: ->
     @protoThreshold = atom.config.get(packageName + ".protoThreshold")
 
   observeConfig: ->
     atom.config.onDidChange(packageName + ".dcdServer", => @updateServerCommand())
     atom.config.onDidChange(packageName + ".dcdClient", => @updateClientCommand())
+    atom.config.onDidChange(packageName + ".dub", => @updateDubCommand())
     atom.config.onDidChange(packageName + ".protoThreshold", => @updateProtoThreshold())
 
   parseCommand: (line) ->
@@ -46,7 +50,9 @@ module.exports =
     childProcess.spawn(command.prog, command.args)
 
   getDubImports: ->
-    dub = childProcess.spawn("dub", ["list"])
+    command = @parseCommand(@dubCommand)
+    command.args.push("list")
+    dub = childProcess.spawn(command.prog, command.args)
     reader = readline.createInterface(input: dub.stdout)
     packages = {}
     firstLine = true


### PR DESCRIPTION
This should allow autocomplete-dcd to run with 'dub' not in path, similar to dcd-client's and dcd-server's config.
Had trouble running Atom in development mode though so this is untested :(
